### PR TITLE
+ Add missing polyfill when upgraded to nuxt@2

### DIFF
--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -47,6 +47,7 @@ module.exports = {
   */
   loading: { color: '#3B8070' },
   plugins: [
+    { src: '~/plugins/polyfill', ssr: false },
     { src: '~/plugins/vuetify' },
     { src: '~/plugins/likecoin-ui-vue' },
     { src: '~/plugins/vue-simple-svg' },

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -3376,6 +3376,11 @@
         }
       }
     },
+    "classlist-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4="
+    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -24,6 +24,8 @@
     "@nuxtjs/google-tag-manager": "^2.1.1",
     "@nuxtjs/sentry": "^2.1.0",
     "axios": "^0.18.0",
+    "classlist-polyfill": "^1.2.0",
+    "core-js": "^2.6.1",
     "lodash.debounce": "^4.0.8",
     "nuxt": "^2.3.4",
     "vue-i18n": "^8.0.0",

--- a/src/plugins/polyfill.js
+++ b/src/plugins/polyfill.js
@@ -1,0 +1,5 @@
+require('core-js/fn/object/assign');
+require('core-js/fn/object/values');
+require('core-js/fn/string/includes');
+require('core-js/fn/array/includes');
+require('classlist-polyfill');


### PR DESCRIPTION
this can get rid of the `.add is undefined` on IE10/11 in sentry report